### PR TITLE
fix discovered logic bugs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,20 @@
+name: Test
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build jpegrip
+        run: make jpegrip
+
+      - name: Run tests
+        run: make test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,165 @@
+# JPEG the Ripper — Claude Code Project Guide
+
+## Project Overview
+
+**jpegrip** is a forensic/data-recovery CLI tool that extracts JPEG files from arbitrary binary data (disk images, raw dumps, etc.). Originally created in 2005 to recover accidentally deleted photos. Current version: **v0.3.3**.
+
+- Language: **C (C89/C90 standard)** — strictly enforced via `-std=c89 -pedantic-errors`
+- License: BSD 3-clause
+- No external dependencies (deliberately avoids libjpeg)
+- Cross-platform: Linux, macOS (universal binary), Windows, **DOS (Borland C++ 3.0)**
+
+## Compiler Compatibility Requirement: Borland C++ 3.0 (DOS)
+
+**This is a hard constraint.** All code must remain compilable with Borland C++ 3.0 (1992), a 16-bit DOS compiler. This is the strictest target and governs what language features are permissible.
+
+### Implications for code changes
+
+| Constraint | Detail |
+|------------|--------|
+| **`int` is 16-bit** | Range −32768..32767. Never use `int` to hold file offsets or sizes. |
+| **`long` is 32-bit** | Max file addressable via `long`/`fseek`/`ftell` is ~2 GB. |
+| **No `stdint.h`** | Not available. Use `unsigned char`, `unsigned long`, etc. explicitly. |
+| **No `snprintf`**  | Borland C++ 3.0 does not provide `snprintf`. Use `sprintf` with bounded inputs. |
+| **No `//` comments** | C89 only — block comments `/* */` exclusively. |
+| **No mixed declarations/code** | All variable declarations must be at the top of their block. |
+| **No VLAs, no designated initialisers** | C89 restrictions apply strictly. |
+| **Memory model awareness** | DOS uses segmented memory (near/far). Avoid assumptions about pointer size. Keep allocations modest. |
+| **No POSIX-only APIs** | `fseek`/`ftell`/`fread`/`fwrite`/`fopen`/`fclose` are safe. Avoid `pread`, `mmap`, etc. |
+| **`EOF` value** | Must treat `EOF` as an opaque `int` constant, not assume it equals −1. |
+| **Large file defines in `compat.h`** | `_LARGEFILE_SOURCE` etc. are ignored by Borland but must not break compilation. Guard with `#ifndef` or compiler checks if needed. |
+
+### What this means practically
+
+- Do **not** introduce `snprintf` — use `sprintf` with inputs that are statically bounded.
+- Do **not** use `int` for sizes, offsets, or file positions — use `long`.
+- Do **not** use C99/C11 features even if GCC/Clang allow them under `-std=c89`.
+- Do **not** rely on `size_t` being 32-bit; on 16-bit DOS it is 16-bit (max 65535).
+- Keep buffer sizes and allocation sizes within 16-bit `size_t` range when possible, or use `unsigned long` explicitly.
+- The `BUF_SIZE 16384` in `jpegrip.c` is near the 16-bit `size_t` limit — do not increase it without care.
+
+## Repository Layout
+
+```
+jpegrip/
+├── main.c          # Entry point, CLI arg parsing, usage text
+├── jpegrip.c       # Core ripping logic
+├── jpegrip.h       # Public API + JPEGRIP_VERSION constant
+├── jpeg.c          # JPEG header parser (thumbnail-aware)
+├── jpeg.h          # jpeg_hdr_size() declaration
+├── jpeghdr.c       # Standalone diagnostic tool for JPEG header inspection
+├── log.c/log.h     # Levelled logging (normal / verbose / trace)
+├── compat.h        # Cross-platform defs (large file support, MAX_FNAME=260)
+├── Makefile        # Primary build system
+├── CMakeLists.txt  # CMake alternative (builds jpegrip + jpeghdr targets)
+├── CMakePresets.json
+├── build.bat       # Windows build script
+├── Dockerfile      # Docker build
+├── sample.bin      # Binary test data
+├── samples/        # Sample JPEG files for testing
+└── mksample.sh     # Script to create sample.bin test data
+```
+
+## How It Works
+
+### Detection Algorithm
+
+1. Scan input file for JPEG SOI signature: `FF D8 FF E0 00 10` (JFIF only)
+2. Parse JPEG header via `jpeg_hdr_size()` to find the **Quantisation Table (DQT)** marker
+   - This skips past APP0, APP1 (EXIF), comments, and — critically — the embedded thumbnail
+   - Thumbnails end with their own EOI (`FF D9`), which would confuse naive SOI→EOI extraction
+3. Search for EOI (`FF D9`) starting *after* the DQT offset
+4. Extract the byte range [SOI..EOI] to a sequentially named file: `jpg00000001.jpg`, `jpg00000002.jpg`, …
+
+### Key Implementation Notes
+
+- **Buffer overlap**: `search_file()` rewinds by `seq_sz` bytes between buffer reads to catch sequences that straddle buffer boundaries (buffer size: 16 KiB)
+- **JFIF-only**: The header parser (`jpeg.c`) only handles APP0 (`FF E0`). Files with APP1 (EXIF) as the second marker will fail `jpeg_hdr_size()` and cause `rip_jpeg()` to abort. This is a known limitation.
+- `RET_ERROR` is defined as `0` (falsy), `RET_OK` as `1` — inverse of typical C convention; functions are checked with `if (!read_marker(...))`.
+- `search_file()` returns the platform `EOF` constant or the internal `ERROR (-2)` / `NOT_FOUND (-3)` sentinels — these are mixed `long` return values, not the same as stdlib `EOF`.
+
+## Building
+
+### macOS (universal binary via lipo)
+```sh
+make jpegrip
+```
+Produces both `x86_jpegrip` (x86_64) and `arm_jpegrip` (arm64), then merges with `lipo`.
+
+### Linux
+```sh
+make jpegrip
+```
+
+### Debug build
+```sh
+make debug jpegrip
+```
+
+### Memory leak check (macOS)
+```sh
+make leaks
+```
+
+### CMake
+```sh
+cmake --preset <preset>   # see CMakePresets.json
+cmake --build build/
+```
+Builds two targets: `jpegrip` and `jpeghdr`.
+
+### Windows
+```bat
+build.bat
+```
+
+### Docker
+```sh
+make docker
+```
+
+## Usage
+
+```
+jpegrip [-v|-vv] <input_file>
+  -v   verbose mode
+  -vv  trace mode (very verbose)
+```
+
+Output JPEGs are written to the **current working directory** as `jpg00000000.jpg`, `jpg00000001.jpg`, etc.
+
+## Source File Responsibilities
+
+| File | Responsibility |
+|------|---------------|
+| `main.c` | `main()`, `usage()`, `run()` — CLI glue |
+| `jpegrip.c` | `rip_jpeg()`, `search_file()`, `search_buf()`, `extract()`, `fmt_string()`, `format_name()` |
+| `jpeg.c` | `jpeg_hdr_size()` — parses JPEG markers to skip thumbnail data |
+| `jpeghdr.c` | Standalone diagnostic: prints header size of a given JPEG |
+| `log.c` | `llog()`, `lverbose()`, `ltrace()`, `set_log_level()` |
+| `compat.h` | `_LARGEFILE*` defines, `MAX_FNAME` (260) |
+
+## Coding Conventions
+
+- **C89 standard** — no C99/C11 features (no `//` comments, no `_Bool`, no VLAs, no designated initialisers, no `stdint.h`)
+- Error labels named `looser:` (intentional misspelling, retained from the original 2005 code)
+- `goto looser` used for cleanup paths (single exit point with resource cleanup)
+- `snprintf` used for filename generation
+- All allocations checked; `malloc` failures go to `looser` label
+
+## Known Limitations / TODO
+
+- Only detects **JFIF** JPEG signatures (`FF D8 FF E0 00 10`); EXIF-only JPEGs (`FF D8 FF E1`) are not found
+- `jpeg_hdr_size()` will fail on EXIF-formatted files (APP1 second marker)
+- Output filenames are sequential — original filenames are not restored
+- TODO (from `TODO` file): implement more file formats beyond JPEG
+
+## Testing
+
+Use `sample.bin` (created by `mksample.sh`) as a test input. Sample JPEG files are in `samples/`.
+
+```sh
+./jpegrip sample.bin
+./jpegrip -v sample.bin
+./jpegrip -vv sample.bin
+```

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ JPEGHDR_SRC=jpeghdr.c jpeg.c log.c
 
 CFLAGS=-pedantic-errors -std=c89
 
-.PHONY: fmt debug
+.PHONY: fmt debug test test-clean
 
 OS=$(shell uname)
 
@@ -61,3 +61,23 @@ docker: clean
 
 fmt:
 	clang-format -i $(JPEGRIP_SRC) $(HDR)
+
+# ---- test targets (native arch only, no lipo) ----
+TEST_BINS = test/test_search_buf test/test_fmt
+TEST_COMMON = jpegrip.c jpeg.c log.c
+
+test/test_search_buf: test/test_search_buf.c $(TEST_COMMON)
+	cc -o $@ $^ $(CFLAGS)
+
+test/test_fmt: test/test_fmt.c $(TEST_COMMON)
+	cc -o $@ $^ $(CFLAGS)
+
+test: $(TEST_BINS)
+	@echo "=== Unit Tests ==="
+	@for t in $(TEST_BINS); do echo "--- $$t ---"; ./$$t || exit 1; done
+	@echo ""
+	@echo "=== Integration Tests ==="
+	@sh test/integration.sh
+
+test-clean:
+	-rm -f $(TEST_BINS)

--- a/jpegrip.c
+++ b/jpegrip.c
@@ -92,13 +92,12 @@ long search_file(FILE *hFile, long start_pos, const unsigned char *seq, const si
 		int file_pos = ftell(hFile);
 
 		if ((bytes_read = fread(buf, sizeof(unsigned char), BUF_SIZE, hFile)) == 0) {
-			if (feof(hFile) || (bytes_read < seq_sz)) {
-				free(buf);
-				return EOF;
-			} else {
+			if (ferror(hFile)) {
 				perror("search_file:  read error");
 				goto looser;
 			}
+			free(buf);
+			return EOF;
 		}
 
 		buf_offset = search_buf(buf, bytes_read, seq, seq_sz);
@@ -230,8 +229,8 @@ int rip_jpeg(FILE *hFile) {
 
 	for (;;) {
 		char output_name[MAX_FNAME];
-		int output_file_sz = 0;
-		int hdr_sz = 0;
+		long output_file_sz = 0;
+		long hdr_sz = 0;
 
 		/* search for start */
 		blob_start = search_file(hFile, blob_end, jpeg_begin, sizeof(jpeg_begin));
@@ -258,7 +257,7 @@ int rip_jpeg(FILE *hFile) {
 		if (blob_end == ERROR) {
 			perror("rip_jpeg: search for jpeg end");
 			return -1;
-		} else if (blob_start == EOF) {
+		} else if (blob_end == EOF) {
 			llog("search terminated prematurely (found start at %ld, but no end)\n");
 			return num_files;
 		}

--- a/main.c
+++ b/main.c
@@ -89,7 +89,7 @@ int run(const char *filename) {
 	llog("Ripping file: %s...\n", filename);
 	if ((f = fopen(filename, "rb")) == 0) {
 		perror("error opening input file");
-		return 0;
+		return -1;
 	}
 	num_files = rip_jpeg(f);
 	if (num_files == -1) {

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,0 +1,2 @@
+test_fmt
+test_search_buf

--- a/test/assert.h
+++ b/test/assert.h
@@ -1,0 +1,29 @@
+/*
+ * Minimal C89 test assertion utilities.
+ * Include this header in exactly one .c file per test binary.
+ */
+#ifndef TEST_ASSERT_H
+#define TEST_ASSERT_H
+
+#include <stdio.h>
+
+static int _t_pass = 0;
+static int _t_fail = 0;
+
+#define TEST_ASSERT(cond, msg) \
+    do { \
+        if (cond) { \
+            printf("  PASS  %s\n", (msg)); \
+            _t_pass++; \
+        } else { \
+            printf("  FAIL  %s  [line %d]\n", (msg), __LINE__); \
+            _t_fail++; \
+        } \
+    } while (0)
+
+static int test_summary(const char *suite) {
+    printf("\n%s: %d passed, %d failed\n", suite, _t_pass, _t_fail);
+    return (_t_fail > 0) ? 1 : 0;
+}
+
+#endif /* TEST_ASSERT_H */

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -1,0 +1,99 @@
+#!/bin/sh
+# Integration tests for jpegrip.
+# Runs against the compiled binary; Unix-only (macOS / Linux).
+# Run from the project root: sh test/integration.sh
+
+set -e
+
+BINARY="${1:-./jpegrip}"
+SAMPLE="sample.bin"
+PASS=0
+FAIL=0
+WORKDIR=/tmp/jpegrip_test_$$
+
+pass() { echo "  PASS  $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL  $1"; FAIL=$((FAIL + 1)); }
+
+cleanup() { rm -rf "$WORKDIR"; }
+trap cleanup EXIT
+
+mkdir -p "$WORKDIR"
+
+# ---- helper: check a file starts with FF D8 (JPEG SOI) ----
+is_jpeg() {
+    [ -f "$1" ] || return 1
+    magic=$(dd if="$1" bs=1 count=2 2>/dev/null | od -An -tx1 | tr -d ' \n')
+    [ "$magic" = "ffd8" ]
+}
+
+echo "=== integration: binary exit codes ==="
+
+# No arguments -> exit 2
+if "$BINARY" > /dev/null 2>&1; then
+    fail "no-args: expected exit code 2, got 0"
+elif [ $? -eq 2 ]; then
+    pass "no-args: exits with code 2"
+else
+    fail "no-args: expected exit code 2, got $?"
+fi
+
+# Non-existent file -> exit non-zero
+if "$BINARY" /tmp/does_not_exist_jpegrip_test 2>/dev/null; then
+    fail "missing-file: expected non-zero exit, got 0"
+else
+    pass "missing-file: exits non-zero for missing input"
+fi
+
+echo ""
+echo "=== integration: sample.bin ==="
+
+if [ ! -f "$SAMPLE" ]; then
+    echo "  SKIP  sample.bin not found — run mksample.sh first"
+else
+    cd "$WORKDIR"
+    "$OLDPWD/$BINARY" "$OLDPWD/$SAMPLE" > /dev/null
+    count=$(ls jpg*.jpg 2>/dev/null | wc -l | tr -d ' ')
+    cd "$OLDPWD"
+
+    if [ "$count" -gt 0 ]; then
+        pass "sample.bin: extracted $count file(s)"
+    else
+        fail "sample.bin: no files extracted"
+    fi
+
+    all_valid=1
+    for f in "$WORKDIR"/jpg*.jpg; do
+        [ -f "$f" ] || continue
+        if ! is_jpeg "$f"; then
+            fail "extracted $f does not start with FF D8"
+            all_valid=0
+        fi
+    done
+    if [ "$all_valid" -eq 1 ] && [ "$count" -gt 0 ]; then
+        pass "sample.bin: all extracted files have valid JPEG SOI"
+    fi
+fi
+
+echo ""
+echo "=== integration: file with no JPEGs ==="
+
+NO_JPEG="$WORKDIR/nojpeg.bin"
+# write 512 bytes of 0x00
+dd if=/dev/zero bs=512 count=1 of="$NO_JPEG" 2>/dev/null
+
+NOJPEG_OUT="$WORKDIR/nojpeg_out"
+mkdir -p "$NOJPEG_OUT"
+cd "$NOJPEG_OUT"
+"$OLDPWD/$BINARY" "$NO_JPEG" > /dev/null
+count=$(ls jpg*.jpg 2>/dev/null | wc -l | tr -d ' ')
+cd "$OLDPWD"
+
+if [ "$count" -eq 0 ]; then
+    pass "no-jpeg file: 0 files extracted"
+else
+    fail "no-jpeg file: expected 0 extracted, got $count"
+fi
+
+echo ""
+echo "integration: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/test/test_fmt.c
+++ b/test/test_fmt.c
@@ -1,0 +1,98 @@
+/*
+ * Unit tests for fmt_string() and format_name() in jpegrip.c
+ * C89 compliant. Uses only stdio.h / string.h (ANSI C89).
+ */
+#include <stdio.h>
+#include <string.h>
+#include "assert.h"
+
+/* Internal functions under test */
+extern int fmt_string(char *buf, int buf_sz, const char *prefix,
+                      int digits, const char *ext);
+extern int format_name(char *output, int output_sz, const char *fmt,
+                       int sequence);
+
+/* ---------- fmt_string tests ---------- */
+
+static void test_fmt_string_basic(void) {
+    char buf[64];
+    char name[64];
+    int r = fmt_string(buf, sizeof(buf), "jpg", 8, "jpg");
+    TEST_ASSERT(r > 0, "fmt_string: returns > 0 on success");
+    /* apply the format string to sequence 0 and check the result */
+    snprintf(name, sizeof(name), buf, 0L);
+    TEST_ASSERT(strcmp(name, "jpg00000000.jpg") == 0,
+                "fmt_string: sequence 0 yields 'jpg00000000.jpg'");
+}
+
+static void test_fmt_string_sequence_42(void) {
+    char buf[64];
+    char name[64];
+    fmt_string(buf, sizeof(buf), "jpg", 8, "jpg");
+    snprintf(name, sizeof(name), buf, 42L);
+    TEST_ASSERT(strcmp(name, "jpg00000042.jpg") == 0,
+                "fmt_string: sequence 42 yields 'jpg00000042.jpg'");
+}
+
+static void test_fmt_string_different_prefix(void) {
+    char buf[64];
+    char name[64];
+    fmt_string(buf, sizeof(buf), "out", 4, "jpeg");
+    snprintf(name, sizeof(name), buf, 7L);
+    TEST_ASSERT(strcmp(name, "out0007.jpeg") == 0,
+                "fmt_string: prefix='out' digits=4 ext='jpeg' seq=7");
+}
+
+static void test_fmt_string_zero_buf(void) {
+    char buf[64];
+    int r = fmt_string(buf, 0, "jpg", 8, "jpg");
+    TEST_ASSERT(r < 0, "fmt_string: zero buf_sz returns < 0");
+}
+
+/* ---------- format_name tests ---------- */
+
+static void test_format_name_zero(void) {
+    char fmt[64];
+    char name[64];
+    fmt_string(fmt, sizeof(fmt), "jpg", 8, "jpg");
+    format_name(name, sizeof(name), fmt, 0);
+    TEST_ASSERT(strcmp(name, "jpg00000000.jpg") == 0,
+                "format_name: sequence 0");
+}
+
+static void test_format_name_large(void) {
+    char fmt[64];
+    char name[64];
+    fmt_string(fmt, sizeof(fmt), "jpg", 8, "jpg");
+    format_name(name, sizeof(name), fmt, 99999999);
+    TEST_ASSERT(strcmp(name, "jpg99999999.jpg") == 0,
+                "format_name: sequence 99999999 fills all 8 digits");
+}
+
+static void test_format_name_sequential(void) {
+    char fmt[64];
+    char a[64], b[64];
+    fmt_string(fmt, sizeof(fmt), "jpg", 8, "jpg");
+    format_name(a, sizeof(a), fmt, 1);
+    format_name(b, sizeof(b), fmt, 2);
+    TEST_ASSERT(strcmp(a, b) != 0, "format_name: sequential names differ");
+}
+
+/* ---------- main ---------- */
+
+int main(void) {
+    printf("=== test_fmt_string ===\n");
+
+    test_fmt_string_basic();
+    test_fmt_string_sequence_42();
+    test_fmt_string_different_prefix();
+    test_fmt_string_zero_buf();
+
+    printf("\n=== test_format_name ===\n");
+
+    test_format_name_zero();
+    test_format_name_large();
+    test_format_name_sequential();
+
+    return test_summary("fmt");
+}

--- a/test/test_search_buf.c
+++ b/test/test_search_buf.c
@@ -1,0 +1,179 @@
+/*
+ * Unit tests for search_buf() and search_file() in jpegrip.c
+ * C89 compliant. Uses only stdio.h / stdlib.h (ANSI C89).
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "assert.h"
+
+/* Internal functions under test - declared here to avoid polluting jpegrip.h */
+extern int  search_buf(const unsigned char *buf, size_t buf_sz,
+                       const unsigned char *seq, size_t seq_sz);
+extern long search_file(FILE *hFile, long start_pos,
+                        const unsigned char *seq, size_t seq_sz);
+
+/* ---------- helpers ---------- */
+
+static FILE *make_tmpfile(const unsigned char *data, size_t sz) {
+    FILE *f = tmpfile();
+    if (f == NULL) {
+        perror("tmpfile");
+        return NULL;
+    }
+    fwrite(data, sizeof(unsigned char), sz, f);
+    rewind(f);
+    return f;
+}
+
+/* ---------- search_buf tests ---------- */
+
+static void test_search_buf_found_at_zero(void) {
+    const unsigned char buf[] = {0xff, 0xd8, 0xff, 0xe0, 0xAA, 0xBB};
+    const unsigned char seq[] = {0xff, 0xd8, 0xff, 0xe0};
+    TEST_ASSERT(search_buf(buf, sizeof(buf), seq, sizeof(seq)) == 0,
+                "search_buf: sequence at offset 0");
+}
+
+static void test_search_buf_found_at_offset(void) {
+    const unsigned char buf[] = {0x00, 0x11, 0xff, 0xd8, 0xff, 0xe0};
+    const unsigned char seq[] = {0xff, 0xd8, 0xff, 0xe0};
+    TEST_ASSERT(search_buf(buf, sizeof(buf), seq, sizeof(seq)) == 2,
+                "search_buf: sequence at offset 2");
+}
+
+static void test_search_buf_not_found(void) {
+    const unsigned char buf[] = {0x00, 0x11, 0x22, 0x33};
+    const unsigned char seq[] = {0xff, 0xd8};
+    TEST_ASSERT(search_buf(buf, sizeof(buf), seq, sizeof(seq)) == -1,
+                "search_buf: sequence not found returns -1");
+}
+
+static void test_search_buf_smaller_than_seq(void) {
+    const unsigned char buf[] = {0xff};
+    const unsigned char seq[] = {0xff, 0xd8};
+    TEST_ASSERT(search_buf(buf, sizeof(buf), seq, sizeof(seq)) == -1,
+                "search_buf: buffer smaller than sequence returns -1");
+}
+
+static void test_search_buf_at_end(void) {
+    const unsigned char buf[] = {0x00, 0x11, 0xff, 0xd9};
+    const unsigned char seq[] = {0xff, 0xd9};
+    TEST_ASSERT(search_buf(buf, sizeof(buf), seq, sizeof(seq)) == 2,
+                "search_buf: sequence at last valid position");
+}
+
+static void test_search_buf_single_byte(void) {
+    const unsigned char buf[] = {0xAA, 0xBB, 0xCC};
+    const unsigned char seq[] = {0xBB};
+    TEST_ASSERT(search_buf(buf, sizeof(buf), seq, sizeof(seq)) == 1,
+                "search_buf: single-byte sequence found at offset 1");
+}
+
+/* ---------- search_file tests ---------- */
+
+static void test_search_file_found_at_start(void) {
+    const unsigned char data[] = {0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0xAA};
+    const unsigned char seq[]  = {0xff, 0xd8, 0xff, 0xe0};
+    FILE *f = make_tmpfile(data, sizeof(data));
+    long result;
+    if (f == NULL) { _t_fail++; return; }
+    result = search_file(f, 0, seq, sizeof(seq));
+    TEST_ASSERT(result == 0, "search_file: found at start of file");
+    fclose(f);
+}
+
+static void test_search_file_found_at_offset(void) {
+    unsigned char data[16];
+    const unsigned char seq[] = {0xff, 0xd8};
+    FILE *f;
+    long result;
+    memset(data, 0x00, sizeof(data));
+    data[10] = 0xff;
+    data[11] = 0xd8;
+    f = make_tmpfile(data, sizeof(data));
+    if (f == NULL) { _t_fail++; return; }
+    result = search_file(f, 0, seq, sizeof(seq));
+    TEST_ASSERT(result == 10, "search_file: found at byte offset 10");
+    fclose(f);
+}
+
+static void test_search_file_not_found(void) {
+    const unsigned char data[] = {0x00, 0x11, 0x22, 0x33, 0x44};
+    const unsigned char seq[]  = {0xff, 0xd8};
+    FILE *f = make_tmpfile(data, sizeof(data));
+    long result;
+    if (f == NULL) { _t_fail++; return; }
+    result = search_file(f, 0, seq, sizeof(seq));
+    TEST_ASSERT(result == EOF, "search_file: returns EOF when not found");
+    fclose(f);
+}
+
+static void test_search_file_empty(void) {
+    const unsigned char seq[] = {0xff, 0xd8};
+    FILE *f = make_tmpfile(NULL, 0);
+    long result;
+    if (f == NULL) { _t_fail++; return; }
+    result = search_file(f, 0, seq, sizeof(seq));
+    TEST_ASSERT(result == EOF, "search_file: returns EOF on empty file");
+    fclose(f);
+}
+
+static void test_search_file_start_pos(void) {
+    /* sequence appears twice; start_pos skips the first occurrence */
+    const unsigned char data[] = {0xff, 0xd9, 0x00, 0x00, 0xff, 0xd9};
+    const unsigned char seq[]  = {0xff, 0xd9};
+    FILE *f = make_tmpfile(data, sizeof(data));
+    long result;
+    if (f == NULL) { _t_fail++; return; }
+    result = search_file(f, 2, seq, sizeof(seq));
+    TEST_ASSERT(result == 4, "search_file: start_pos skips earlier occurrence");
+    fclose(f);
+}
+
+/*
+ * Buffer-boundary test: sequence straddles the 16384-byte read buffer edge.
+ * Writes 16383 zero bytes, then the target sequence, then checks it is found.
+ * This verifies the seq_sz-byte rewind overlap in search_file().
+ */
+static void test_search_file_buffer_boundary(void) {
+    const int BEFORE = 16383; /* BUF_SIZE - 1 */
+    const unsigned char seq[] = {0xff, 0xd8, 0xff, 0xe0};
+    FILE *f = tmpfile();
+    long result;
+    int i;
+    if (f == NULL) { _t_fail++; return; }
+    for (i = 0; i < BEFORE; i++) {
+        fputc(0x00, f);
+    }
+    fwrite(seq, sizeof(unsigned char), sizeof(seq), f);
+    rewind(f);
+    result = search_file(f, 0, seq, sizeof(seq));
+    TEST_ASSERT(result == BEFORE,
+                "search_file: sequence spanning buffer boundary is found");
+    fclose(f);
+}
+
+/* ---------- main ---------- */
+
+int main(void) {
+    printf("=== test_search_buf ===\n");
+
+    test_search_buf_found_at_zero();
+    test_search_buf_found_at_offset();
+    test_search_buf_not_found();
+    test_search_buf_smaller_than_seq();
+    test_search_buf_at_end();
+    test_search_buf_single_byte();
+
+    printf("\n=== test_search_file ===\n");
+
+    test_search_file_found_at_start();
+    test_search_file_found_at_offset();
+    test_search_file_not_found();
+    test_search_file_empty();
+    test_search_file_start_pos();
+    test_search_file_buffer_boundary();
+
+    return test_summary("search");
+}


### PR DESCRIPTION
Bug #1 (jpegrip.c:260) — blob_start == EOF → blob_end == EOF. The
premature-termination guard now checks the variable that was just assigned.

Bug #2 (jpegrip.c:94-101) — Replaced the unreachable bytes_read < seq_sz
branch with ferror(hFile). fread returning 0 now correctly distinguishes I/O
error (via ferror) from EOF — both of which were previously silently treated
as EOF.

Bug #3 (jpegrip.c:232-233) — int output_file_sz and int hdr_sz both changed to
long. I included hdr_sz as well since it receives the return value of
jpeg_hdr_size() which is typed long — same truncation class as the reported
bug, and particularly relevant under Borland where int is 16-bit.
